### PR TITLE
🤖 Add a GET /ping endpoint that returns {pong: true} with 200 status

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,16 @@
 const http = require('http');
+
 const handler = (req, res) => {
+  if (req.method === 'GET' && req.url === '/ping') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ pong: true }));
+    return;
+  }
+
   res.writeHead(404);
   res.end('Not Found');
 };
+
 const server = http.createServer(handler);
 if (require.main === module) server.listen(3000);
 module.exports = { handler, server };

--- a/test.js
+++ b/test.js
@@ -1,2 +1,44 @@
-console.log('No tests yet');
-process.exit(1);
+const assert = require('assert');
+const { handler } = require('./index');
+
+const createMockRes = () => {
+  let statusCode = null;
+  let headers = {};
+  let body = '';
+  let resolve;
+
+  const done = new Promise((res) => {
+    resolve = res;
+  });
+
+  const res = {
+    writeHead(code, headerMap = {}) {
+      statusCode = code;
+      headers = { ...headers, ...headerMap };
+    },
+    end(chunk = '') {
+      body += chunk;
+      resolve({ statusCode, headers, body });
+    },
+  };
+
+  return { res, done };
+};
+
+const run = async () => {
+  const req = { method: 'GET', url: '/ping' };
+  const { res, done } = createMockRes();
+
+  handler(req, res);
+  const response = await done;
+
+  assert.strictEqual(response.statusCode, 200, 'expected 200 status');
+  const parsed = JSON.parse(response.body);
+  assert.deepStrictEqual(parsed, { pong: true }, 'expected pong payload');
+  console.log('All tests passed');
+};
+
+run().catch((error) => {
+  console.error('Test failure:', error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Task
Add a GET /ping endpoint that returns {pong: true} with 200 status

## Changes
```
 index.js |  8 ++++++++
 test.js  | 46 ++++++++++++++++++++++++++++++++++++++++++++--
 2 files changed, 52 insertions(+), 2 deletions(-)
```

## Commits
897ccb8 feat: Add a GET /ping endpoint that returns {pong: true} with 200 status (via bg-agent)

---
*Automated by [bg-agent](https://github.com/ensostream/background-agent) via Ralph Loop + E2B sandbox*